### PR TITLE
add weights_format to package name

### DIFF
--- a/src/bioimageio-packager.imjoy.html
+++ b/src/bioimageio-packager.imjoy.html
@@ -238,7 +238,8 @@ async function downloadModel(rootUrl, spec, weightsFormat, showMessage, showProg
   console.time("zipping")
   const zipBlob = new Blob([UZIP.encode(files2zip, true)]);
   console.timeEnd('zipping')
-  await api.exportFile(zipBlob, spec.name.replace(/\s+/g, '-').toLowerCase() + '.zip')
+  const package_name = spec.name + "_" + weightsFormat + ".zip"
+  await api.exportFile(zipBlob, package_name.replace(/\s+/g, '-').toLowerCase())
   await showMessage('Model package was exported successfully')
 
 }


### PR DESCRIPTION
This PR adds the weights_format id to the package file name.

@akreshuk notices that it is inconvenient not to be able to distinguish downloaded model packages by their file name, although they may contain a different set of weights. 

note: in https://github.com/bioimage-io/spec-bioimage-io/pull/182 the same is implemented for the python packager