### PR TITLE
Update manifest.bioimage.io.yaml

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -23,7 +23,7 @@ config:
 application:
   - id: BioImageIO-Packager
     source: https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/bioimageio-packager.imjoy.html
-  - id: Notebook Preview
+  - id: NotebookPreview
     source: https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html
   - id: ImJoy
     source: https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master/src/imjoy-app.imjoy.html


### PR DESCRIPTION
spaces in `id` are not allowed and lead to CI failure: https://github.com/bioimage-io/collection-bioimage-io/runs/4619449746?check_suite_focus=true