### PR TITLE
Added contact info for BMZ

### DIFF
--- a/collection.bioimage.io.yaml
+++ b/collection.bioimage.io.yaml
@@ -24,6 +24,14 @@ config:
     - application
   default_type: application
   url_root: https://raw.githubusercontent.com/imjoy-team/bioimage-io-models/master
+  docs: https://imjoy.io/docs/#/
+  contact:
+    - name: Wei Ouyang
+      email: wei.ouyang@scilifelab.se
+      github: oeway
+      affiliation:
+        - name: KTH
+          url: https://www.kth.se/en
 
 collection:
   - id: GenericBioEngineApp


### PR DESCRIPTION
Due to changes in the available documentation for the BioImage Model Zoo (bioimage.io) regarding the Community Partners, new contact info for ImJoy needed to be added to the manifest.